### PR TITLE
Add basic auth support

### DIFF
--- a/landavailability/landavailability/settings.py
+++ b/landavailability/landavailability/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'v8q^p#^661*^0llwj8*jnt7xx^*%hx29)qno_qunv-^v3pdonn'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['e5e9df78.ngrok.io']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -45,6 +45,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'webclient.middleware.BasicAuthenticationMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -125,3 +126,6 @@ STATICFILES_DIRS = (
 )
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+HTTP_USERNAME = os.environ.get('HTTP_USERNAME')
+HTTP_PASSWORD = os.environ.get('HTTP_PASSWORD')

--- a/landavailability/webclient/middleware.py
+++ b/landavailability/webclient/middleware.py
@@ -1,0 +1,44 @@
+import os
+import base64
+
+from django.conf import settings
+from django.http import HttpResponse
+
+
+def basic_challenge(realm='Restricted Access'):
+    response =  HttpResponse('Authorization Required')
+    response['WWW-Authenticate'] = 'Basic realm="%s"' % (realm)
+    response.status_code = 401
+    return response
+
+def basic_authenticate(authentication):
+    (authmeth, auth) = authentication.split(' ',1)
+    if 'basic' != authmeth.lower():
+        return None
+
+    auth = base64.b64decode(bytes(auth, 'utf-8')).decode()
+
+    username, password = auth.split(':',1)
+    auth_username = settings.HTTP_USERNAME
+    auth_password = settings.HTTP_PASSWORD
+    return username == auth_username and password == auth_password
+
+class BasicAuthenticationMiddleware(object):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if not settings.HTTP_USERNAME:
+            return response
+
+        if 'HTTP_AUTHORIZATION' not in request.META:
+            return basic_challenge()
+
+        authenticated = basic_authenticate(request.META['HTTP_AUTHORIZATION'])
+        if authenticated:
+            return response
+
+        return basic_challenge()


### PR DESCRIPTION
So that it isn't immediately accessible to bots and spiders and people,
adds basic auth support.

In the environment you should make sure that HTTP_USERNAME and
HTTP_PASSWORD both have a value to activate the middleware.